### PR TITLE
Fix broken credentials_json example

### DIFF
--- a/workflows/deploy-cloudrun/cloudrun-docker.yml
+++ b/workflows/deploy-cloudrun/cloudrun-docker.yml
@@ -82,7 +82,7 @@ jobs:
       #   uses: 'google-github-actions/auth@v0'
       #   with:
       #     credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
-      #     token_format: `access_token`
+      #     token_format: 'access_token'
 
       # BEGIN - Docker auth and build (NOTE: If you already have a container image, these Docker steps can be omitted)
 

--- a/workflows/deploy-cloudrun/cloudrun-docker.yml
+++ b/workflows/deploy-cloudrun/cloudrun-docker.yml
@@ -82,6 +82,7 @@ jobs:
       #   uses: 'google-github-actions/auth@v0'
       #   with:
       #     credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+      #     token_format: `access_token`
 
       # BEGIN - Docker auth and build (NOTE: If you already have a container image, these Docker steps can be omitted)
 


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
When authenticating with `credentials_json`, if you do not specify the `token_format` the build breaks. I added the fix to the example.

![image](https://user-images.githubusercontent.com/1341777/190628523-c724f492-45e3-4165-a619-8ce9c5c631b8.png)
