### PR TITLE
Add Cloud Deploy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This repository holds several references to example workflows and demonstrates h
 
 ## Available Examples
 
+### [create-cloud-deploy-release](workflows/create-cloud-deploy-release/README.md)
+
+| Name                                                         | Starter                   | Description      |
+| ------------------------------------------------------------ | ------------------------- | ---------------- |
+|[cloud-deploy-to-cloud-run](workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml) |  | Build a Docker container, publish it to Google Artifact Registry, and use Cloud Deploy to deploy to Google Cloud Run. |
+
 ### [deploy-cloudrun](workflows/deploy-cloudrun/README.md)
 
 | Name                                                         | Starter                   | Description      |

--- a/properties/cloud-deploy-to-cloud-run.properties.json
+++ b/properties/cloud-deploy-to-cloud-run.properties.json
@@ -1,0 +1,7 @@
+{
+  "name": "Create a Cloud Deploy release and deploy to Cloud Run",
+  "description": "Build a Docker container, publish it to Google Artifact Registry, and use Cloud Deploy to deploy to Google Cloud Run.",
+  "creator": "Google Cloud",
+  "iconName": "google-cloud",
+  "categories": ["Cloud Deploy", "Deployment", "Containers", "Cloud Run", "Serverless"]
+}

--- a/workflow.config.json
+++ b/workflow.config.json
@@ -1,4 +1,10 @@
 {
+  "cloud-deploy-to-cloud-run": {
+    "starter": false,
+    "type": "deployments",
+    "workflowPath": "workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml",
+    "propertiesPath": "properties/cloud-deploy-to-cloud-run.properties.json"
+  },
   "cloudrun-declarative": {
     "starter": false,
     "type": "deployments",

--- a/workflows/create-cloud-deploy-release/README.md
+++ b/workflows/create-cloud-deploy-release/README.md
@@ -1,0 +1,1 @@
+# create-cloud-deploy-release examples

--- a/workflows/create-cloud-deploy-release/app/Dockerfile
+++ b/workflows/create-cloud-deploy-release/app/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.19 AS builder
+WORKDIR /go/src/hello
+COPY . .
+RUN CGO_ENABLED=0 go build -o /go/bin/hello
+
+FROM gcr.io/distroless/static-debian11
+COPY --from=builder /go/bin/hello /
+CMD ["/hello"]
+

--- a/workflows/create-cloud-deploy-release/app/go.mod
+++ b/workflows/create-cloud-deploy-release/app/go.mod
@@ -1,0 +1,4 @@
+module app
+
+go 1.19
+

--- a/workflows/create-cloud-deploy-release/app/main.go
+++ b/workflows/create-cloud-deploy-release/app/main.go
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	log.Print("starting server...")
+	http.HandleFunc("/", handler)
+
+	// Determine port for HTTP service.
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("defaulting to port %s", port)
+	}
+
+	// Start HTTP server.
+	log.Printf("listening on port %s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	name := os.Getenv("TARGET")
+	if name == "" {
+		name = "World"
+	}
+	fmt.Fprintf(w, "\nHello %s! 🎉\n\n", name)
+	log.Printf("Sent response, target customization was '%s'", name)
+}

--- a/workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml
+++ b/workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml
@@ -1,0 +1,150 @@
+# This workflow builds and pushes a Docker container to Google Artifact Registry
+# and creates a release in Cloud Deploy using a declarative YAML Service
+# specification (service-*.yaml) when a commit is pushed to the $default-branch branch.
+#
+# Overview:
+#
+# 1. Authenticate to Google Cloud
+# 2. Configure Docker for Artifact Registry
+# 3. Build a container image
+# 4. Publish it to Google Artifact Registry
+# 5. Create YAML manifests from templates
+# 6. Create a Cloud Deploy delivery pipeline and targets (staging and production)
+# 7. Create a Cloud Deploy release to deploy the container image to Cloud Run
+#
+# To configure this workflow:
+#
+# 1. Ensure the required Google Cloud APIs are enabled:
+#
+#    Cloud Build          cloudbuild.googleapis.com
+#    Cloud Deploy         clouddeploy.googleapis.com
+#    Cloud Run            run.googleapis.com
+#    Artifact Registry    artifactregistry.googleapis.com
+#
+# 2. Create and configure Workload Identity Federation for GitHub (https://github.com/google-github-actions/auth#setting-up-workload-identity-federation)
+#
+# 3. Ensure the required IAM permissions are granted to the service account configured in
+#    Workload Identity Federation:
+#
+#    Artifact Registry
+#      roles/artifactregistry.writer    (Project or repository level)
+#
+#    Cloud Deploy
+#      roles/clouddeploy.operator       (To configure Cloud Deploy)
+#
+#    Cloud Storage
+#      roles/storage.admin              (To write release packages)
+#
+# 4. Ensure the required IAM permissions are granted to the default compute
+#    service account:
+#
+#    Cloud Logging
+#      roles/logging.logWriter          (To write logs)
+#
+#    Cloud Run
+#      roles/run.developer              (To create Cloud Run services)
+#
+#    Cloud Storage
+#      storage/object.viewer            (To read Cloud Deploy artifacts)
+#      storage/object.creator           (To write Cloud Deploy artifacts)
+#
+#    Additionally, the default compute service account requires permissions to "ActAs" itself
+#    to be able to deploy to Cloud Run. You can add this permission with the following command:
+#
+#    gcloud iam service-accounts add-iam-policy-binding $(gcloud projects describe ${PROJECT_ID} \
+#    --format="value(projectNumber)")-compute@developer.gserviceaccount.com \
+#    --member="serviceAccount:$(gcloud projects describe ${PROJECT_ID}\
+#    --format="value(projectNumber)")-compute@developer.gserviceaccount.com" \
+#    --role="roles/iam.serviceAccountUser"
+#
+#    NOTE: You should always follow the principle of least privilege when assigning IAM roles
+#
+# 4. Create GitHub secrets for WIF_PROVIDER and WIF_SERVICE_ACCOUNT
+#
+# 5. Change the values for the PROJECT_ID, GAR_LOCATION, and REGION environment variables (below).
+#
+# NOTE: To use Google Container Registry instead, replace ${{ env.GAR_LOCATION }}-docker.pkg.dev with gcr.io
+#
+# For more support on how to run this workflow, please visit https://github.com/marketplace/actions/create-cloud-deploy-release
+#
+# Further reading:
+#   Cloud Deploy IAM permissions              - https://cloud.google.com/deploy/docs/iam-roles-permissions
+#   Cloud Run IAM permissions                 - https://cloud.google.com/run/docs/deploying
+#   Cloud Run IAM roles                       - https://cloud.google.com/run/docs/reference/iam/roles
+#   Cloud Run targets in Cloud Deploy         - https://cloud.google.com/deploy/docs/run-targets
+
+name: Build app and create a release in Cloud Deploy
+
+on:
+  push:
+    branches:
+      - $default_branch
+
+env:
+  PROJECT_ID: YOUR_PROJECT_ID # TODO: update Google Cloud project id
+  GAR_LOCATION: YOUR_GAR_LOCATION # TODO: update Artifact Registry location
+  REGION: YOUR_APP_REGION # TODO: update Cloud Run service region
+  APP: app
+
+jobs:
+  deploy:
+    # Add 'id-token' with the intended permissions for workload identity federation
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v3'
+
+      - name: 'Google auth'
+        id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}' # e.g. - projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider
+          service_account: '${{ secrets.WIF_SERVICE_ACCOUNT }}' # e.g. - my-service-account@my-project.iam.gserviceaccount.com
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+        with:
+          project_id: '${{ secrets.PROJECT_ID }}'
+
+      - name: 'Docker auth'
+        run: |-
+          gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev
+
+      - name: 'Build and push container'
+        run: |-
+          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.APP }}/${{ env.APP }}:${{ github.sha }}" ./app
+          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.APP }}/${{ env.APP }}:${{ github.sha }}"
+
+      - name: 'Render templatised config manifests'
+        run: |-
+          export PROJECT_ID="${{ env.PROJECT_ID }}"
+          export REGION="${{ env.REGION }}"
+          for template in $(ls config/*.template.yaml); do envsubst < ${template} > ${template%%.*}.yaml ; done
+
+      - name: 'Create Cloud Deploy delivery pipeline'
+        run: |-
+          gcloud deploy apply --file config/clouddeploy.yaml --region ${{ env.GAR_LOCATION }}
+
+      - name: 'Create release name'
+        run: |-
+          echo "RELEASE_NAME=${{ env.APP }}-${GITHUB_SHA::7}-${GITHUB_RUN_NUMBER}" >> ${GITHUB_ENV}
+
+      - name: 'Create Cloud Deploy release'
+        id: 'release'
+        uses: 'google-github-actions/create-cloud-deploy-release@v0'
+        with:
+          delivery_pipeline: '${{ env.APP }}'
+          name: '${{ env.RELEASE_NAME }}'
+          region: '${{ env.REGION }}'
+          description: '${{ env.GITHUB_COMMIT_MSG }}'
+          skaffold_file: 'config/skaffold.yaml'
+          images: 'app=${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.APP }}/${{ env.APP }}:${{ github.sha }}'
+
+      - name: 'Report Cloud Deploy release'
+        run: |-
+          echo "Created release ${{ steps.release.outputs.name }} "
+          echo "Release link ${{ steps.release.outputs.link }} "

--- a/workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml
+++ b/workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml
@@ -59,9 +59,9 @@
 #
 #    NOTE: You should always follow the principle of least privilege when assigning IAM roles
 #
-# 4. Create GitHub secrets for WIF_PROVIDER and WIF_SERVICE_ACCOUNT
+# 5. Create GitHub secrets for WIF_PROVIDER and WIF_SERVICE_ACCOUNT
 #
-# 5. Change the values for the PROJECT_ID, GAR_LOCATION, and REGION environment variables (below).
+# 6. Change the values for the PROJECT_ID, GAR_LOCATION, and REGION environment variables (below).
 #
 # NOTE: To use Google Container Registry instead, replace ${{ env.GAR_LOCATION }}-docker.pkg.dev with gcr.io
 #

--- a/workflows/create-cloud-deploy-release/config/app-prod.template.yaml
+++ b/workflows/create-cloud-deploy-release/config/app-prod.template.yaml
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: 'app-prod'
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/maxScale: '1'
+    spec:
+      containers:
+      - name: 'app'
+        image: 'app'
+        env:
+          - name: 'TARGET'
+            value: 'Prod'

--- a/workflows/create-cloud-deploy-release/config/app-staging.template.yaml
+++ b/workflows/create-cloud-deploy-release/config/app-staging.template.yaml
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: 'app-staging'
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/maxScale: '1'
+    spec:
+      containers:
+      - name: 'app'
+        image: 'app'
+        env:
+          - name: 'TARGET'
+            value: 'Staging'

--- a/workflows/create-cloud-deploy-release/config/clouddeploy.template.yaml
+++ b/workflows/create-cloud-deploy-release/config/clouddeploy.template.yaml
@@ -1,0 +1,41 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: deploy.cloud.google.com/v1
+kind: DeliveryPipeline
+metadata:
+  name: 'app'
+description: 'Deployment pipeline for demo app'
+serialPipeline:
+  stages:
+    - targetId: 'staging'
+      profiles: ['staging']
+    - targetId: 'prod'
+      profiles: ['prod']
+---
+apiVersion: deploy.cloud.google.com/v1
+kind: Target
+metadata:
+  name: 'staging'
+description: 'Staging target'
+run:
+  location: 'projects/${PROJECT_ID}/locations/${REGION}'
+---
+apiVersion: deploy.cloud.google.com/v1
+kind: Target
+metadata:
+  name: 'prod'
+description: 'Production target'
+run:
+  location: 'projects/${PROJECT_ID}/locations/${REGION}'

--- a/workflows/create-cloud-deploy-release/config/skaffold.template.yaml
+++ b/workflows/create-cloud-deploy-release/config/skaffold.template.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skaffold/v3alpha1
+kind: Config
+metadata:
+  name: 'app'
+deploy:
+  cloudrun: {}
+profiles:
+  - name: 'staging'
+    manifests:
+      rawYaml:
+        - 'app-staging.yaml'
+  - name: 'prod'
+    manifests:
+      rawYaml:
+        - 'app-prod.yaml'


### PR DESCRIPTION
This PR adds an example workflow for the [`create-cloud-deploy-release`](https://github.com/marketplace/actions/create-cloud-deploy-release) GitHub action. The example workflow:

1. Builds an example (included) demo application as a container image
1. Pushes the container image to [Google Artifact Registry](https://cloud.google.com/artifact-registry)
1. Creates a [Google Cloud Deploy](https://cloud.google.com/deploy) delivery pipeline
1. Uses the [`create-cloud-deploy-release`](https://github.com/marketplace/actions/create-cloud-deploy-release) action to create a release and deploy the example application to [Google Cloud Run](https://cloud.google.com/run).
