### PR TITLE
Use PROJECT_ID from environment

### DIFF
--- a/workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml
+++ b/workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml
@@ -108,7 +108,7 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
         with:
-          project_id: '${{ secrets.PROJECT_ID }}'
+          project_id: '${{ env.PROJECT_ID }}'
 
       - name: 'Docker auth'
         run: |-


### PR DESCRIPTION
While it's possible to use `PROJECT_ID` from a secret, as it's already in the environment we should read from there.