### PR TITLE
Fix storage related roles for compute service account in cloud deploy release example

### DIFF
--- a/workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml
+++ b/workflows/create-cloud-deploy-release/cloud-deploy-to-cloud-run.yml
@@ -45,8 +45,8 @@
 #      roles/run.developer              (To create Cloud Run services)
 #
 #    Cloud Storage
-#      storage/object.viewer            (To read Cloud Deploy artifacts)
-#      storage/object.creator           (To write Cloud Deploy artifacts)
+#      roles/storage.objectViewer       (To read Cloud Deploy artifacts)
+#      roles/storage.objectCreator      (To write Cloud Deploy artifacts)
 #
 #    Additionally, the default compute service account requires permissions to "ActAs" itself
 #    to be able to deploy to Cloud Run. You can add this permission with the following command:


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

The roles listed in the instructions of cloud deploy to cloud run example are not working. They generate the following error:

```
400: The role name must be in the form "roles/{role}", "organizations/{organization_id}/roles/{role}", or "projects/{project_id}/roles/{role}"., badRequest
```

I checked the roles on [the Storage IAM Roles page](https://cloud.google.com/storage/docs/access-control/iam-roles) and corrected them.