### PR TITLE
Fix Cloud Run action example using service-account-based auth

### DIFF
--- a/workflows/deploy-cloudrun/cloudrun-declarative.yml
+++ b/workflows/deploy-cloudrun/cloudrun-declarative.yml
@@ -85,6 +85,7 @@ jobs:
       #   uses: 'google-github-actions/auth@v0'
       #   with:
       #     credentials_json: '${{ secrets.GCP_CREDENTIALS }}''
+      #     token_format: 'access_token'
 
       # BEGIN - Docker auth and build (NOTE: If you already have a container image, these Docker steps can be omitted)
 


### PR DESCRIPTION
Added missing `token_format: 'access_token'` for the `google-github-actions/auth@v0` step, fixing Cloud Run action example using service-account-based auth, ensuring docker-auth works